### PR TITLE
Add trivial data levels for HYDRA

### DIFF
--- a/gtpcdata/CMakeLists.txt
+++ b/gtpcdata/CMakeLists.txt
@@ -27,8 +27,9 @@ link_directories( ${LINK_DIRECTORIES})
 set(SRCS
 R3BGTPCPoint.cxx
 R3BGTPCProjPoint.cxx
-#R3BGTPCMappedData.cxx
-#R3BGTPCCalData.cxx
+R3BGTPCMappedData.cxx
+R3BGTPCCalData.cxx
+R3BGTPCHitData.cxx
 )
 
 # fill list of header files from list of source files

--- a/gtpcdata/R3BGTPCCalData.cxx
+++ b/gtpcdata/R3BGTPCCalData.cxx
@@ -1,0 +1,29 @@
+/******************************************************************************
+ *   Copyright (C) 2019 GSI Helmholtzzentrum für Schwerionenforschung GmbH    *
+ *   Copyright (C) 2019 Members of R3B Collaboration                          *
+ *                                                                            *
+ *             This software is distributed under the terms of the            *
+ *                 GNU General Public Licence (GPL) version 3,                *
+ *                    copied verbatim in the file "LICENSE".                  *
+ *                                                                            *
+ * In applying this license GSI does not waive the privileges and immunities  *
+ * granted to it by virtue of its status as an Intergovernmental Organization *
+ * or submit itself to any jurisdiction.                                      *
+ ******************************************************************************/
+
+#include "R3BGTPCCalData.h"
+
+R3BGTPCCalData::R3BGTPCCalData()
+    : fPadId(0)
+    , fADC(0)
+{
+}
+
+R3BGTPCCalData::R3BGTPCCalData(UShort_t padId,
+                               std::vector<UShort_t>  adc)
+    : fPadId(padId)
+    , fADC(adc)
+{
+}
+
+ClassImp(R3BGTPCCalData);

--- a/gtpcdata/R3BGTPCCalData.h
+++ b/gtpcdata/R3BGTPCCalData.h
@@ -1,0 +1,49 @@
+/******************************************************************************
+ *   Copyright (C) 2019 GSI Helmholtzzentrum für Schwerionenforschung GmbH    *
+ *   Copyright (C) 2019 Members of R3B Collaboration                          *
+ *                                                                            *
+ *             This software is distributed under the terms of the            *
+ *                 GNU General Public Licence (GPL) version 3,                *
+ *                    copied verbatim in the file "LICENSE".                  *
+ *                                                                            *
+ * In applying this license GSI does not waive the privileges and immunities  *
+ * granted to it by virtue of its status as an Intergovernmental Organization *
+ * or submit itself to any jurisdiction.                                      *
+ ******************************************************************************/
+
+#ifndef R3BGTPCCALDATA_H
+#define R3BGTPCCALDATA_H
+
+#include "TObject.h"
+#include <stdint.h>
+
+class R3BGTPCCalData : public TObject
+{
+
+  public:
+    // Default Constructor
+    R3BGTPCCalData();
+
+    /** Standard Constructor
+     *@param padId               Crystal unique identifier
+     *@param adc                  Calibrated adc energies
+     **/
+    R3BGTPCCalData(UShort_t padId,
+                   std::vector<UShort_t>  adc);
+
+    // Destructor
+    virtual ~R3BGTPCCalData() {}
+
+    // Getters
+    inline const UShort_t& GetPadId() const { return fPadId; }
+    inline const std::vector<UShort_t>& GetEnergy() const { return fADC; }
+
+  protected:
+    UShort_t fPadId;          // Pad unique identifier
+    std::vector<UShort_t> fADC;    // ADC measurements, variable time bucket
+
+  public:
+    ClassDef(R3BGTPCCalData, 1)
+};
+
+#endif

--- a/gtpcdata/R3BGTPCDataLinkDef.h
+++ b/gtpcdata/R3BGTPCDataLinkDef.h
@@ -8,7 +8,8 @@
 
 #pragma link C++ class R3BGTPCPoint + ;
 #pragma link C++ class R3BGTPCProjPoint + ;
-//#pragma link C++ class R3BGTPCMappedData+;
-//#pragma link C++ class R3BGTPCCalData+;
+#pragma link C++ class R3BGTPCMappedData+;
+#pragma link C++ class R3BGTPCCalData+;
+#pragma link C++ class R3BGTPCHitData+;
 
 #endif

--- a/gtpcdata/R3BGTPCHitData.cxx
+++ b/gtpcdata/R3BGTPCHitData.cxx
@@ -1,0 +1,35 @@
+/******************************************************************************
+ *   Copyright (C) 2019 GSI Helmholtzzentrum für Schwerionenforschung GmbH    *
+ *   Copyright (C) 2019 Members of R3B Collaboration                          *
+ *                                                                            *
+ *             This software is distributed under the terms of the            *
+ *                 GNU General Public Licence (GPL) version 3,                *
+ *                    copied verbatim in the file "LICENSE".                  *
+ *                                                                            *
+ * In applying this license GSI does not waive the privileges and immunities  *
+ * granted to it by virtue of its status as an Intergovernmental Organization *
+ * or submit itself to any jurisdiction.                                      *
+ ******************************************************************************/
+
+#include "R3BGTPCHitData.h"
+
+R3BGTPCHitData::R3BGTPCHitData()
+    : fX(0)
+    , fY(0)
+    , fZ(0)
+    , fLongWidth(0)
+    , fEnergy(0)
+{
+}
+
+R3BGTPCHitData::R3BGTPCHitData(Double_t x, Double_t y, Double_t z,
+               Double_t longWidth, Double_t energy)
+    : fX(x)
+    , fY(y)
+    , fZ(z)
+    , fLongWidth(longWidth)
+    , fEnergy(energy)
+{
+}
+
+ClassImp(R3BGTPCHitData);

--- a/gtpcdata/R3BGTPCHitData.h
+++ b/gtpcdata/R3BGTPCHitData.h
@@ -1,0 +1,58 @@
+/******************************************************************************
+ *   Copyright (C) 2019 GSI Helmholtzzentrum für Schwerionenforschung GmbH    *
+ *   Copyright (C) 2019 Members of R3B Collaboration                          *
+ *                                                                            *
+ *             This software is distributed under the terms of the            *
+ *                 GNU General Public Licence (GPL) version 3,                *
+ *                    copied verbatim in the file "LICENSE".                  *
+ *                                                                            *
+ * In applying this license GSI does not waive the privileges and immunities  *
+ * granted to it by virtue of its status as an Intergovernmental Organization *
+ * or submit itself to any jurisdiction.                                      *
+ ******************************************************************************/
+
+#ifndef R3BGTPCHITDATA_H
+#define R3BGTPCHITDATA_H
+
+#include "TObject.h"
+#include <stdint.h>
+
+class R3BGTPCHitData : public TObject
+{
+
+  public:
+    // Default Constructor
+    R3BGTPCHitData();
+
+    /** Standard Constructor
+    *@param x          X position of the hit in the gas
+    *@param y          Y position of the hit in the gas
+    *@param z          Z position of the hit in the gas
+    *@param longWidth  Longitudinal width of electron cloud
+    *@param energy     Total energy atributed to the hit
+     **/
+    R3BGTPCHitData(Double_t x, Double_t y, Double_t z,
+                   Double_t longWidth, Double_t energy);
+
+    // Destructor
+    virtual ~R3BGTPCHitData() {}
+
+    // Getters
+    inline const Double_t GetX() const { return fX; }
+    inline const Double_t GetY() const { return fY; }
+    inline const Double_t GetZ() const { return fZ; }
+    inline const Double_t GetLongWidth() const { return fLongWidth; }
+    inline const Double_t GetEnergy() const { return fEnergy; }
+
+  protected:
+    Double_t fX;         // X position of the hit in the gas
+    Double_t fY;         // Y position of the hit in the gas
+    Double_t fZ;         // Z position of the hit in the gas
+    Double_t fLongWidth; // Longitudinal width of electron cloud
+    Double_t fEnergy;    // Total energy atributed to the hit
+
+  public:
+    ClassDef(R3BGTPCHitData, 1)
+};
+
+#endif

--- a/gtpcdata/R3BGTPCMappedData.cxx
+++ b/gtpcdata/R3BGTPCMappedData.cxx
@@ -1,0 +1,34 @@
+/******************************************************************************
+ *   Copyright (C) 2019 GSI Helmholtzzentrum für Schwerionenforschung GmbH    *
+ *   Copyright (C) 2019 Members of R3B Collaboration                          *
+ *                                                                            *
+ *             This software is distributed under the terms of the            *
+ *                 GNU General Public Licence (GPL) version 3,                *
+ *                    copied verbatim in the file "LICENSE".                  *
+ *                                                                            *
+ * In applying this license GSI does not waive the privileges and immunities  *
+ * granted to it by virtue of its status as an Intergovernmental Organization *
+ * or submit itself to any jurisdiction.                                      *
+ ******************************************************************************/
+
+#include "R3BGTPCMappedData.h"
+
+R3BGTPCMappedData::R3BGTPCMappedData()
+    : fPadId(0)
+    , fADC(0)
+    , fIsValid(0)
+    , fIsPedestalSubtracted(0)
+{
+}
+
+R3BGTPCMappedData::R3BGTPCMappedData(UShort_t padId,
+                                     std::vector<UShort_t>  adc,
+                                     Bool_t isValid,
+                                     Bool_t isPedestalSubtracted)
+    : fPadId(padId)
+    , fADC(adc)
+    , fIsValid(isValid)
+    , fIsPedestalSubtracted(isPedestalSubtracted){
+}
+
+ClassImp(R3BGTPCMappedData);

--- a/gtpcdata/R3BGTPCMappedData.h
+++ b/gtpcdata/R3BGTPCMappedData.h
@@ -1,0 +1,58 @@
+/******************************************************************************
+ *   Copyright (C) 2019 GSI Helmholtzzentrum für Schwerionenforschung GmbH    *
+ *   Copyright (C) 2019 Members of R3B Collaboration                          *
+ *                                                                            *
+ *             This software is distributed under the terms of the            *
+ *                 GNU General Public Licence (GPL) version 3,                *
+ *                    copied verbatim in the file "LICENSE".                  *
+ *                                                                            *
+ * In applying this license GSI does not waive the privileges and immunities  *
+ * granted to it by virtue of its status as an Intergovernmental Organization *
+ * or submit itself to any jurisdiction.                                      *
+ ******************************************************************************/
+
+#ifndef R3BGTPCMAPPEDDATA_H
+#define R3BGTPCMAPPEDDATA_H
+
+#include "TObject.h"
+#include <stdint.h>
+
+class R3BGTPCMappedData : public TObject
+{
+
+  public:
+    // Default Constructor
+    R3BGTPCMappedData();
+
+    /** Standard Constructor
+     *@param padId               Crystal unique identifier
+     *@param adc                  Vector of ADC measurements, variable size
+     *@param isValid              Data validity check
+     *@param isPedestalSubtracted Pedestal subtraction flag
+     **/
+    R3BGTPCMappedData(UShort_t padId,
+                      std::vector<UShort_t>  adc,
+                      Bool_t isValid,
+                      Bool_t isPedestalSubtracted);
+
+    // Destructor
+    virtual ~R3BGTPCMappedData() {}
+
+    // Getters
+    inline const UShort_t& GetPadId() const { return fPadId; }
+    inline const std::vector<UShort_t>& GetEnergy() const { return fADC; }
+    inline const Bool_t& IsValid() const { return fIsValid; }
+    inline const Bool_t& IsPedestalSubtracted() const
+    { return fIsPedestalSubtracted; }
+
+  protected:
+    UShort_t fPadId;                // Pad unique identifier
+    std::vector<UShort_t> fADC;          // ADC measurements, variable time bucket
+    Bool_t fIsValid;                // Valid check NEEDED??
+    Bool_t fIsPedestalSubtracted;   // Needed? REMOVE ME IF IT IS A CTE. CHARACTERISTIC OF DATA
+
+  public:
+    ClassDef(R3BGTPCMappedData, 1)
+};
+
+#endif


### PR DESCRIPTION
Mapped corresponds to the entry level filled by the Readers. It consist of a pad
identifier and an array (variable std::vector) of timebuckets with the adc info,
plus some additional control or status flags. A single mapped object per pad
with signal above threshold is expected per event, filling TClonesArray of
mapped objets per event.
Cal corresponds to the same information with calibrated adc info.
Hit corresponds to a 3D voxel in the chamber with some energy and width info, in
a way that a single cal object could create several 3D hits if multiple peaks are
detected in the adc array.