### PR TITLE
Add digitalization via R3BGTPCLangevin class up to R3BGTPCCalData level

### DIFF
--- a/gtpc/R3BGTPCElecPar.cxx
+++ b/gtpc/R3BGTPCElecPar.cxx
@@ -51,6 +51,8 @@ void R3BGTPCElecPar::putParams(FairParamList* list)
     list->add("GTPCTimeBinSize", TimeBinSize);
     list->add("GTPCShapingTime", ShapingTime);
     list->add("GTPCThreshold", Threshold);
+    list->add("GTPCDriftEField", DriftEField);
+    list->add("GTPCDriftTimeStep", DriftTimeStep);
 }
 
 // ----  Method getParams ------------------------------------------------------
@@ -91,6 +93,17 @@ Bool_t R3BGTPCElecPar::getParams(FairParamList* list)
         LOG(INFO) << "---Could not initialize GTPCThreshold";
         return kFALSE;
     }
+    if (!(list->fill("GTPCDriftEField", &DriftEField)))
+    {
+        LOG(INFO) << "---Could not initialize GTPCDriftEField";
+        return kFALSE;
+    }
+    if (!(list->fill("GTPCDriftTimeStep", &DriftTimeStep)))
+    {
+        LOG(INFO) << "---Could not initialize GTPCDriftTimeStep";
+        return kFALSE;
+    }
+
     return kTRUE;
 }
 
@@ -106,8 +119,10 @@ void R3BGTPCElecPar::printParams()
               << "GTPCTheta (Polya) " << Theta << ",  "
               << "GTPCNoiseRMS " << NoiseRMS << " e- RMS,  "
               << "GTPCTimeBinSize " << TimeBinSize << " ns,  "
-              << "GTPCShapingTime " << ShapingTime << " ns"
-              << "GTPCThreshold " << Threshold << " times noise rms" << endl;
+              << "GTPCShapingTime " << ShapingTime << " ns, "
+              << "GTPCThreshold " << Threshold << " times noise rms, "
+              << "GTPCDriftEField " << DriftEField << " V/m, "
+              << "GTPCDriftTimeStep " << DriftTimeStep << " ns" << endl;
 }
 
 ClassImp(R3BGTPCElecPar);

--- a/gtpc/R3BGTPCElecPar.h
+++ b/gtpc/R3BGTPCElecPar.h
@@ -52,6 +52,8 @@ class R3BGTPCElecPar : public FairParGenericSet
     const Double_t GetTimeBinSize() { return TimeBinSize; }
     const Double_t GetShapingTime() { return ShapingTime; }
     const Double_t GetThreshold() { return Threshold; }
+    const Double_t GetDriftEField() { return DriftEField; }
+    const Double_t GetDriftTimeStep() { return DriftTimeStep; }
 
     void SetGain(Double_t value) { Gain = value; }
     void SetTheta(Double_t value) { Theta = value; }
@@ -59,6 +61,8 @@ class R3BGTPCElecPar : public FairParGenericSet
     void SetTimeBinSize(Double_t value) { TimeBinSize = value; }
     void SetShapingTime(Double_t value) { ShapingTime = value; }
     void SetThreshold(Double_t value) { Threshold = value; }
+    void SetDriftEField(Double_t value) { DriftEField = value; }
+    void SetDriftTimeStep(Double_t value) { DriftTimeStep = value; }
 
   private:
     Double_t Gain;
@@ -67,6 +71,8 @@ class R3BGTPCElecPar : public FairParGenericSet
     Double_t TimeBinSize;
     Double_t ShapingTime;
     Double_t Threshold;
+    Double_t DriftEField;
+    Double_t DriftTimeStep;
 
     const R3BGTPCElecPar& operator=(const R3BGTPCElecPar&); /*< an assignment operator>*/
     R3BGTPCElecPar(const R3BGTPCElecPar&);                  /*< a copy constructor >*/

--- a/gtpc/R3BGTPCLangevin.h
+++ b/gtpc/R3BGTPCLangevin.h
@@ -18,6 +18,7 @@
 #define R3BGTPCLANGEVIN_H
 
 #include "FairTask.h"
+#include "R3BGTPCCalData.h"
 #include "R3BGTPCElecPar.h"
 #include "R3BGTPCGasPar.h"
 #include "R3BGTPCGeoPar.h"
@@ -32,6 +33,7 @@
  *
  * For each event, get the R3BGTPCPoints and determine the projection on the pad plane
  *   Input:  Branch GTPCPoints = TClonesArray("R3BGTPCPoint")
+ *   Output: Branch GTPCCalData = TClonesArray("R3BGTPCCalData")
  *   Output: Branch GTPCProjPoint = TClonesArray("R3BGTPCProjPoint")
  */
 
@@ -44,17 +46,11 @@ class R3BGTPCLangevin : public FairTask
     /** Destructor **/
     ~R3BGTPCLangevin();
 
-    /** Virtual method Exec **/
-    void Exec(Option_t*);
-
-    /** Set parameters -- To be removed when parameter containers are ready **/
-    void SetDriftParameters(Double_t ion, Double_t driftv, Double_t tDiff, Double_t lDiff, Double_t fanoFactor);
-
-    void SetSizeOfVirtualPad(Double_t size);
-
-  protected:
     /** Virtual method Init **/
     virtual InitStatus Init();
+
+    /** Virtual method Exec **/
+    void Exec(Option_t*);
 
     /** Virtual method ReInit **/
     virtual InitStatus ReInit();
@@ -67,10 +63,8 @@ class R3BGTPCLangevin : public FairTask
 
     void SetParameter();
 
-    TClonesArray* fGTPCPoints;
-    TClonesArray* fGTPCProjPoint;
-    // MCTrack- vertex information
-    TClonesArray* MCTrackCA;
+    void SetProjPointsAsOutput() { outputMode = 1; }
+    void SetCalDataAsOutput() { outputMode = 0; }
 
   private:
     // Mapping of  virtualPadID to ProjPoint object pointer
@@ -85,13 +79,25 @@ class R3BGTPCLangevin : public FairTask
     Double_t fHalfSizeTPC_Y;    //!< Half size Y of the TPC drift volume [cm]
     Double_t fHalfSizeTPC_Z;    //!< Half size Z of the TPC drift volume [cm]
     Double_t fSizeOfVirtualPad; //!< Number of virtual pad division per cm (default 1)
-    Int_t fDetectorType;        //!< Detector type: 1 for prototype, 2 for FullBeamIn, 3 for FullBeamOut
+    Double_t fDriftEField;      //!< Drift electric field [V/m]
+    Double_t fDriftTimeStep;    //!< Time Step between drift parameters calculation
+
+    Int_t fDetectorType; //!< Detector type: 1 for prototype, 2 for FullBeamIn, 3 for FullBeamOut
 
     R3BGTPCGeoPar* fGTPCGeoPar;   //!< Geometry parameter container
     R3BGTPCGasPar* fGTPCGasPar;   //!< Gas parameter container
     R3BGTPCElecPar* fGTPCElecPar; //!< Electronic parameter container
 
-    ClassDef(R3BGTPCLangevin, 1)
+    Int_t outputMode; //!< Selects Cal(0) or ProjPoint(1) as output level. Default 0
+    TClonesArray* fGTPCPointsCA;
+    TClonesArray* fGTPCCalDataCA;
+    TClonesArray* fGTPCProjPointCA;
+    // MCTrack- vertex information
+    TClonesArray* fMCTrackCA;
+
+    // R3BGTPCCalData* AddCalData();
+
+    ClassDef(R3BGTPCLangevin, 2)
 };
 
 #endif // R3BGTPCLANGEVIN_H

--- a/gtpcdata/R3BGTPCCalData.h
+++ b/gtpcdata/R3BGTPCCalData.h
@@ -26,7 +26,7 @@ class R3BGTPCCalData : public TObject
 
     /** Standard Constructor
      *@param padId               Crystal unique identifier
-     *@param adc                  Calibrated adc energies
+     *@param adc                 Calibrated adc energies
      **/
     R3BGTPCCalData(UShort_t padId, std::vector<UShort_t> adc);
 
@@ -36,6 +36,10 @@ class R3BGTPCCalData : public TObject
     // Getters
     inline const UShort_t& GetPadId() const { return fPadId; }
     inline const std::vector<UShort_t>& GetADC() const { return fADC; }
+
+    // Setter
+    void SetPadId(UShort_t padId) { fPadId = padId; }
+    void SetADC(Double_t time) { fADC.at(time)++; }
 
   protected:
     UShort_t fPadId;            // Pad unique identifier

--- a/params/Electronic_FileSetup.par
+++ b/params/Electronic_FileSetup.par
@@ -10,4 +10,6 @@ GTPCNoiseRMS:   Double_t  700.
 GTPCTimeBinSize:   Double_t  20.0
 GTPCShapingTime:   Double_t  300.
 GTPCThreshold:   Double_t  5.
+GTPCDriftEField:   Double_t  100000.
+GTPCDriftTimeStep:   Double_t  500.
 ##############################################################################


### PR DESCRIPTION
Digitization can be done now up to R3BGTPCCalData (new standard model) or up to
the old R3BGTPCProjPoint which contains more simulation information. A parameter
outputMode controls the output style.