### PR TITLE
Added the real pad plane display for Langevin and Projector classes

### DIFF
--- a/gtpc/R3BGTPCLangevin.cxx
+++ b/gtpc/R3BGTPCLangevin.cxx
@@ -39,11 +39,9 @@ R3BGTPCLangevin::R3BGTPCLangevin()
     fTransDiff = 0;
     fLongDiff = 0;
     fFanoFactor = 0;
-    fSizeOfVirtualPad = 0;
     fHalfSizeTPC_X = 0.;
     fHalfSizeTPC_Y = 0.;
     fHalfSizeTPC_Z = 0.;
-    fSizeOfVirtualPad = 0;
     fTimeBinSize = 0;
     fDriftEField = 0.;
     fDriftTimeStep = 0.;
@@ -63,11 +61,6 @@ R3BGTPCLangevin::~R3BGTPCLangevin()
     {
         fGTPCCalDataCA->Delete();
         delete fGTPCCalDataCA;
-    }
-    if (fGTPCProjPointCA)
-    {
-        fGTPCProjPointCA->Delete();
-        delete fGTPCProjPointCA;
     }
     if (fMCTrackCA)
     {
@@ -123,7 +116,6 @@ void R3BGTPCLangevin::SetParameter()
     fHalfSizeTPC_X = fGTPCGeoPar->GetActiveRegionx() / 2.;
     fHalfSizeTPC_Y = fGTPCGeoPar->GetActiveRegiony() / 2.;
     fHalfSizeTPC_Z = fGTPCGeoPar->GetActiveRegionz() / 2.;
-    fSizeOfVirtualPad = fGTPCGeoPar->GetPadSize(); // 1 means pads of 1cm^2, 10 means pads of 1mm^2, ...
     fDetectorType = fGTPCGeoPar->GetDetectorType();
     fOffsetX = fGTPCGeoPar->GetGladOffsetX(); // X offset [cm]
     fOffsetZ = fGTPCGeoPar->GetGladOffsetZ(); // Z offset [cm]

--- a/gtpc/R3BGTPCLaserGen.cxx
+++ b/gtpc/R3BGTPCLaserGen.cxx
@@ -123,7 +123,6 @@ void R3BGTPCLaserGen::SetParameter()
     fHalfSizeTPC_X = fGTPCGeoPar->GetActiveRegionx() / 2.; //[cm]
     fHalfSizeTPC_Y = fGTPCGeoPar->GetActiveRegiony() / 2.; //[cm]
     fHalfSizeTPC_Z = fGTPCGeoPar->GetActiveRegionz() / 2.; //[cm]
-    fSizeOfVirtualPad = fGTPCGeoPar->GetPadSize();         // 1 means pads of 1cm^2, 10 means pads of 1mm^2, ...
     fOffsetX = fGTPCGeoPar->GetTargetOffsetX();            // X offset [cm]
     fOffsetZ = fGTPCGeoPar->GetTargetOffsetZ();            // Z offset [cm]
     fTargetOffsetX = fGTPCGeoPar->GetGladOffsetX();
@@ -222,11 +221,6 @@ void R3BGTPCLaserGen::SetLaserParameters(Double_t alpha,
     fZIn = z_in;            // cm
     fMaxLength = maxLength; // cm
                             // fPointDistance = pointDistance; // cm
-}
-
-void R3BGTPCLaserGen::SetSizeOfVirtualPad(Double_t size)
-{
-    fSizeOfVirtualPad = size; // 1 means pads of 1cm^2, 10 means pads of 1mm^2, ...
 }
 
 void R3BGTPCLaserGen::SetNumberOfGeneratedElectrons(Double_t ele)

--- a/gtpc/R3BGTPCLaserGen.h
+++ b/gtpc/R3BGTPCLaserGen.h
@@ -58,7 +58,6 @@ class R3BGTPCLaserGen : public FairTask
                             Double_t y_in,
                             Double_t z_in,
                             Double_t maxLength);
-    void SetSizeOfVirtualPad(Double_t size);
     void SetNumberOfGeneratedElectrons(Double_t ele);
     void SetProjPointsAsOutput() { outputMode = 1; }
     void SetCalDataAsOutput() { outputMode = 0; }
@@ -89,16 +88,15 @@ class R3BGTPCLaserGen : public FairTask
 
     std::map<Int_t, R3BGTPCProjPoint*> fProjPointMap;
 
-    Double_t fEIonization;      //!< Effective ionization energy of gas [eV] NOTUSED
-    Double_t fDriftVelocity;    //!< Drift velocity in gas [cm/ns]
-    Double_t fTransDiff;        //!< Transversal diffusion coefficient [cm^2/ns]
-    Double_t fLongDiff;         //!< Longitudinal diffusion coefficient [cm^2/ns]
-    Double_t fFanoFactor;       //!< Fano factor to calculate electron number
-                                //!< fluctuations NOTUSED
-    Double_t fHalfSizeTPC_X;    //!< Half size X of the TPC drift volume [cm]
-    Double_t fHalfSizeTPC_Y;    //!< Half size Y of the TPC drift volume [cm]
-    Double_t fHalfSizeTPC_Z;    //!< Half size Z of the TPC drift volume [cm]
-    Double_t fSizeOfVirtualPad; //!< Number of virtual pad division per cm (default 1)
+    Double_t fEIonization;   //!< Effective ionization energy of gas [eV] NOTUSED
+    Double_t fDriftVelocity; //!< Drift velocity in gas [cm/ns]
+    Double_t fTransDiff;     //!< Transversal diffusion coefficient [cm^2/ns]
+    Double_t fLongDiff;      //!< Longitudinal diffusion coefficient [cm^2/ns]
+    Double_t fFanoFactor;    //!< Fano factor to calculate electron number
+                             //!< fluctuations NOTUSED
+    Double_t fHalfSizeTPC_X; //!< Half size X of the TPC drift volume [cm]
+    Double_t fHalfSizeTPC_Y; //!< Half size Y of the TPC drift volume [cm]
+    Double_t fHalfSizeTPC_Z; //!< Half size Z of the TPC drift volume [cm]
     Double_t fDriftEField;
     Double_t fDriftTimeStep;
     Double_t fTimeBinSize;

--- a/gtpc/R3BGTPCProjector.h
+++ b/gtpc/R3BGTPCProjector.h
@@ -56,8 +56,6 @@ class R3BGTPCProjector : public FairTask
     /** Set parameters -- To be removed when parameter containers are ready **/
     void SetDriftParameters(Double_t ion, Double_t driftv, Double_t tDiff, Double_t lDiff, Double_t fanoFactor);
 
-    void SetSizeOfVirtualPad(Double_t size);
-
     void SetProjPointsAsOutput() { outputMode = 1; }
     void SetCalDataAsOutput() { outputMode = 0; }
 
@@ -96,6 +94,10 @@ class R3BGTPCProjector : public FairTask
     Double_t fHalfSizeTPC_Z;    //!< Half size Z of the TPC drift volume [cm]
     Double_t fSizeOfVirtualPad; //!< Number of virtual pad division per cm (default 1)
     Double_t fTimeBinSize;      //!< Time size of each bin in the time vector [ns]
+    Double_t fOffsetX;          //!< Offset X between the active target and the padplane
+    Double_t fOffsetZ;          //!< Offset Z between the active target and the padplane
+    Double_t fDriftEField;      //!< Drift electric field [V/cm]
+    Double_t fDriftTimeStep;    //!< Time Step between drift parameters calculation [ns]
     Int_t fDetectorType;        //!< Detector type: 1 for prototype, 2 for FullBeamIn, 3
                                 //!< for FullBeamOut
     Int_t outputMode;           //!< Selects Cal(0) or ProjPoint(1) as output level. Default 0

--- a/macros/proj/run_proj.C
+++ b/macros/proj/run_proj.C
@@ -18,7 +18,7 @@ void run_proj(TString GEOTAG = "Prototype")
     inFile = "../sim/" + GEOTAG + "/sim.root";
     parFile = "../sim/" + GEOTAG + "/par.root";
     outFile = "./" + GEOTAG + "/proj.root";
-    GTPCGeoParamsFile = geoPath + "/glad-tpc/params/HYDRAprototype_FileSetup.par";
+    GTPCGeoParamsFile = geoPath + "/glad-tpc/params/HYDRAprototype_FileSetup_v2_02082022.par";
 
     GTPCGeoParamsFile.ReplaceAll("//", "/");
 
@@ -57,7 +57,7 @@ void run_proj(TString GEOTAG = "Prototype")
                             gasPar->GetTransDiff(),
                             gasPar->GetFanoFactor());
     pro->SetSizeOfVirtualPad(geoPar->GetPadSize()); // 1 means pads of 1cm^2, 10 means pads of 1mm^2...
-
+    pro->SetProjPointsAsOutput();
     fRun->AddTask(pro);
 
     fRun->Init();

--- a/macros/run_full_laser.sh
+++ b/macros/run_full_laser.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+echo -e "Are you sure? If it's not your first use, this script will overwrite your previous results.\n"
+read -p "Type y or Y to proceed:		" -n 1 -r
+echo 
+if [[ $REPLY =~ ^[Yy]$ ]]; then
+cd ./sim
+echo -e "\n----------------Simulating!----------------\n"
+root -b run_simHYDRA_laser.C <<EOF
+.q
+EOF
+echo -e "\n----------------Projecting into the pad plane the tracks inside the active region!----------------\n"
+cd ../proj
+root -l 'run_laser_gen.C(kTRUE)' <<EOF
+.q
+EOF
+echo -e "\n----------------Representing the results in the pad plane----------------\n"
+cd ../vis
+root -l run_laserVis.C
+echo -e "\n----------------Projecting into the pad plane (again) the tracks inside the active region!----------------\n"
+cd ../proj
+root -l run_laser_gen.C <<EOF
+.q
+EOF
+echo -e "\n----------------Performing the track reconstruction!----------------\n"
+cd ../reco
+root -l run_reconstruction_laser.C <<EOF
+.q
+EOF
+echo -e "\n----------------Comparing with the generated laser!----------------\n"
+root -l residues_laser.C
+echo -e "\n----------------End of the simulation!----------------\n"
+fi
+

--- a/macros/vis/readVPadPlane.C
+++ b/macros/vis/readVPadPlane.C
@@ -102,6 +102,12 @@ void reader(const char* inputSimFile, Int_t event)
     Double_t fHalfSizeTPC_Z = geoPar->GetActiveRegionz() / 2.; // 100cm in Z (column)
     Double_t fSizeOfVirtualPad = geoPar->GetPadSize();         // 1: pads of 1cm^2 , 10: pads of 1mm^2
     Double_t fMaxDriftTime = (round)((geoPar->GetActiveRegiony() / gasPar->GetDriftVelocity()) * pow(10, -3)); // us
+    std::shared_ptr<R3BGTPCMap> fTPCMap;
+    TH2* fPadPlane;
+    fTPCMap = std::make_shared<R3BGTPCMap>();
+    fTPCMap->GeneratePadPlane();
+    fPadPlane = fTPCMap->GetPadPlane();
+
     // END OF SETUP
 
     gROOT->SetStyle("Default");
@@ -230,9 +236,14 @@ void reader(const char* inputSimFile, Int_t event)
                 // xPad = ppoint->GetVirtualPadID() % (Int_t)(44);
                 // zPad = (ppoint->GetVirtualPadID() - xPad) / (44);
                 tPad = ((TH1S*)(ppoint->GetTimeDistribution()))->GetMean();
+                /*
                 htrackInPads->GetBinXYZ(ppoint->GetVirtualPadID(), xPad, zPad, yPad);
                 xPad--;
                 zPad--;
+                */
+
+                xPad = fTPCMap->CalcPadCenter(ppoint->GetVirtualPadID())[1] / 2;
+                zPad = fTPCMap->CalcPadCenter(ppoint->GetVirtualPadID())[0] / 2;
 
                 htrackInPads->Fill(xPad, zPad, ppoint->GetCharge());
                 hdriftTimeInPads->Fill(xPad, zPad, tPad);


### PR DESCRIPTION
Typo fixing

Implementation of the read pad plane to the classes R3BGTPCLangevin and R3BGTPCProjector.

---

Checklist:

* [x] Rebased against `dev` branch
* [x] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [x] Followed the [pull request guidlines](https://opensource.creativecommons.org/contributing-code/pr-guidelines/) and the [Git workflow](https://github.com/AnarManafov/GitWorkflow/blob/master/GitWorkflow.markdown)
* [x] Followed the [seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
