### PR TITLE
Deleted variables regarding the virtual pad plane (no longer supported)

### DIFF
--- a/gtpc/R3BGTPCProjector.cxx
+++ b/gtpc/R3BGTPCProjector.cxx
@@ -111,7 +111,6 @@ void R3BGTPCProjector::SetParameter()
     fTransDiff = fGTPCGasPar->GetTransDiff();         // [cm^2/ns]?
     fLongDiff = fGTPCGasPar->GetLongDiff();           // [cm^2/ns]?
     fFanoFactor = fGTPCGasPar->GetFanoFactor();
-    fSizeOfVirtualPad = fGTPCGeoPar->GetPadSize(); // 1 means pads of 1cm^2, 10 means pads of 1mm^2, ...
     fHalfSizeTPC_X = fGTPCGeoPar->GetActiveRegionx() / 2.;
     fHalfSizeTPC_Y = fGTPCGeoPar->GetActiveRegiony() / 2.;
     fHalfSizeTPC_Z = fGTPCGeoPar->GetActiveRegionz() / 2.;
@@ -339,15 +338,6 @@ void R3BGTPCProjector::Exec(Option_t*)
             // std::cout<<" proj Z "<<projZ<<" - proj Y "<<projY<<"\n";
             Int_t padID = fPadPlane->Fill((projZ - fOffsetZ) * 10.0,
                                           (projX - fOffsetX) * 10.0); // in mm
-
-            // Deprecated code to remove
-            /*(if (fDetectorType == 1)
-                padID = (44) * (Int_t)((projZ - ZOffset) / 0.2) + (Int_t)((projX -
-            XOffset) / 0.2); // 2mm else padID = (2 * fHalfSizeTPC_X *
-            fSizeOfVirtualPad) * (Int_t)((projZ - ZOffset) * fSizeOfVirtualPad) +
-                        (Int_t)((projX - XOffset) * fSizeOfVirtualPad); // FULL HYDRA
-            padplane has not been decided yet
-        */
 
             if (outputMode == 0)
             { // Output: TClonesArray of R3BGTPCCalData

--- a/gtpc/R3BGTPCProjector.h
+++ b/gtpc/R3BGTPCProjector.h
@@ -84,23 +84,22 @@ class R3BGTPCProjector : public FairTask
     // Mapping of  virtualPadID to ProjPoint object pointer
     // std::map<Int_t, R3BGTPCProjPoint*> fProjPointMap;
 
-    Double_t fEIonization;      //!< Effective ionization energy of gas [eV]
-    Double_t fDriftVelocity;    //!< Drift velocity in gas [cm/ns]
-    Double_t fTransDiff;        //!< Transversal diffusion coefficient [cm^2/ns]
-    Double_t fLongDiff;         //!< Longitudinal diffusion coefficient [cm^2/ns]
-    Double_t fFanoFactor;       //!< Fano factor to calculate electron number fluctuations
-    Double_t fHalfSizeTPC_X;    //!< Half size X of the TPC drift volume [cm]
-    Double_t fHalfSizeTPC_Y;    //!< Half size Y of the TPC drift volume [cm]
-    Double_t fHalfSizeTPC_Z;    //!< Half size Z of the TPC drift volume [cm]
-    Double_t fSizeOfVirtualPad; //!< Number of virtual pad division per cm (default 1)
-    Double_t fTimeBinSize;      //!< Time size of each bin in the time vector [ns]
-    Double_t fOffsetX;          //!< Offset X between the active target and the padplane
-    Double_t fOffsetZ;          //!< Offset Z between the active target and the padplane
-    Double_t fDriftEField;      //!< Drift electric field [V/cm]
-    Double_t fDriftTimeStep;    //!< Time Step between drift parameters calculation [ns]
-    Int_t fDetectorType;        //!< Detector type: 1 for prototype, 2 for FullBeamIn, 3
-                                //!< for FullBeamOut
-    Int_t outputMode;           //!< Selects Cal(0) or ProjPoint(1) as output level. Default 0
+    Double_t fEIonization;   //!< Effective ionization energy of gas [eV]
+    Double_t fDriftVelocity; //!< Drift velocity in gas [cm/ns]
+    Double_t fTransDiff;     //!< Transversal diffusion coefficient [cm^2/ns]
+    Double_t fLongDiff;      //!< Longitudinal diffusion coefficient [cm^2/ns]
+    Double_t fFanoFactor;    //!< Fano factor to calculate electron number fluctuations
+    Double_t fHalfSizeTPC_X; //!< Half size X of the TPC drift volume [cm]
+    Double_t fHalfSizeTPC_Y; //!< Half size Y of the TPC drift volume [cm]
+    Double_t fHalfSizeTPC_Z; //!< Half size Z of the TPC drift volume [cm]
+    Double_t fTimeBinSize;   //!< Time size of each bin in the time vector [ns]
+    Double_t fOffsetX;       //!< Offset X between the active target and the padplane
+    Double_t fOffsetZ;       //!< Offset Z between the active target and the padplane
+    Double_t fDriftEField;   //!< Drift electric field [V/cm]
+    Double_t fDriftTimeStep; //!< Time Step between drift parameters calculation [ns]
+    Int_t fDetectorType;     //!< Detector type: 1 for prototype, 2 for FullBeamIn, 3
+                             //!< for FullBeamOut
+    Int_t outputMode;        //!< Selects Cal(0) or ProjPoint(1) as output level. Default 0
 
     R3BGTPCGeoPar* fGTPCGeoPar;   //!< Geometry parameter container
     R3BGTPCGasPar* fGTPCGasPar;   //!< Gas parameter container

--- a/macros/proj/run_proj.C
+++ b/macros/proj/run_proj.C
@@ -56,7 +56,6 @@ void run_proj(TString GEOTAG = "Prototype")
                             gasPar->GetLongDiff(),
                             gasPar->GetTransDiff(),
                             gasPar->GetFanoFactor());
-    pro->SetSizeOfVirtualPad(geoPar->GetPadSize()); // 1 means pads of 1cm^2, 10 means pads of 1mm^2...
     pro->SetProjPointsAsOutput();
     fRun->AddTask(pro);
 


### PR DESCRIPTION
Some variables regarding the virtual pad plane have been deleted. This fixed an error in the macro run_proj.C. 

---

Checklist:

* [x] Rebased against `dev` branch
* [x] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [x] Followed the [pull request guidlines](https://opensource.creativecommons.org/contributing-code/pr-guidelines/) and the [Git workflow](https://github.com/AnarManafov/GitWorkflow/blob/master/GitWorkflow.markdown)
* [x] Followed the [seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
